### PR TITLE
eclass/versionator: Reduce eutils to estack

### DIFF
--- a/eclass/versionator.eclass
+++ b/eclass/versionator.eclass
@@ -28,7 +28,7 @@
 if [[ -z ${_VERSIONATOR_ECLASS} ]]; then
 _VERSIONATOR_ECLASS=1
 
-inherit eutils
+inherit estack
 
 # @FUNCTION: get_all_version_components
 # @USAGE: [version]


### PR DESCRIPTION
This eclass only uses functions that were split into estack
This action may expose packages which depend implicitly on this and they should be fixed.

This PR is to test if anything breaks tree wide